### PR TITLE
fix CJS & ESM distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "version": "1.1.0",
   "author": "Greg Bergé <berge.greg@gmail.com>",
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/react-merge-refs.esm.js",
-  "typings": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "exports": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "repository": "github:gregberge/react-merge-refs",
   "funding": {
     "type": "github",
@@ -22,7 +22,7 @@
     "release": "standard-version && conventional-github-releaser --preset angular",
     "start": "tsdx watch",
     "test": "tsdx test",
-    "build": "tsdx build"
+    "build": "tsdx build --format cjs"
   },
   "devDependencies": {
     "@testing-library/react": "^11.2.5",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import type * as React from "react";
 
 export default function mergeRefs<T = any>(
   refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>


### PR DESCRIPTION
## Summary

Previously, `react-merge-refs` was distributing both CJS _and_ ESM, which is unnecessary (ESM can import CJS just fine). Additionally the package.json was not properly configured to publicise the ESM distribution.

Now, only CJS is built and distributed, and package.json properly publicises both for use by either CJS or ESM.

Fixes #16

## Test plan

These should both return `{ default: [Function: mergeRefs] }` (they fail on `main`, but succeed on this branch).

```
$ node \
--input-type=module \
-e "import mergeRefs from 'react-merge-refs'; console.log(mergeRefs)"
```

```
$> node \
--input-type=commonjs \
-e "const mergeRefs = require('react-merge-refs'); console.log(mergeRefs)"
```

This should not be a breaking change.