### PR TITLE
Support .cjs file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "2.0.0",
   "sideEffects": false,
   "type": "module",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,4 +30,14 @@ export default [
       format: "es",
     },
   }),
+  bundle({
+    plugins: [esbuild(esbuildConfig)],
+    output: [
+      {
+        file: `dist/index.cjs`,
+        format: "cjs",
+        sourcemap: true,
+      },
+    ],
+  }),
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- [Create React App](https://create-react-app.dev/)'s jest (react-scipts) can not import esm(.mjs) package.
  - like this, [Use in create-react-app - Ant Design](https://ant.design/docs/react/use-with-create-react-app#Test-with-Jest)
- For pass the test with react-merge-refs, it has to export .cjs file.
- Probably, the module bundler does not affect the `"module": "./dist/index.mjs",` (ESM) loading priority over `"main": "./dist/index.cjs"`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

No diff in src.
