### PR TITLE
feat: Allow a ref to be undefined in the types

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -30,7 +30,9 @@ test("mergeRefs with undefined and null refs", () => {
   const refAsFunc = jest.fn();
   const refAsObj = { current: undefined };
   const Example: React.FC<{ visible: boolean }> = ({ visible }) => {
-    return visible ? <Dummy ref={mergeRefs([null, undefined, refAsFunc, refAsObj])} /> : null;
+    return visible ? (
+      <Dummy ref={mergeRefs([null, undefined, refAsFunc, refAsObj])} />
+    ) : null;
   };
   const { rerender } = render(<Example visible />);
   expect(refAsFunc).toHaveBeenCalledTimes(1);

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -21,3 +21,23 @@ test("mergeRefs", () => {
   expect(refAsFunc).toHaveBeenCalledWith(null);
   expect(refAsObj.current).toBe(null);
 });
+
+test("mergeRefs with undefined and null refs", () => {
+  const Dummy = React.forwardRef(function Dummy(_, ref) {
+    React.useImperativeHandle(ref, () => "refValue");
+    return null;
+  });
+  const refAsFunc = jest.fn();
+  const refAsObj = { current: undefined };
+  const Example: React.FC<{ visible: boolean }> = ({ visible }) => {
+    return visible ? <Dummy ref={mergeRefs([null, undefined, refAsFunc, refAsObj])} /> : null;
+  };
+  const { rerender } = render(<Example visible />);
+  expect(refAsFunc).toHaveBeenCalledTimes(1);
+  expect(refAsFunc).toHaveBeenCalledWith("refValue");
+  expect(refAsObj.current).toBe("refValue");
+  rerender(<Example visible={false} />);
+  expect(refAsFunc).toHaveBeenCalledTimes(2);
+  expect(refAsFunc).toHaveBeenCalledWith(null);
+  expect(refAsObj.current).toBe(null);
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react";
 
 export function mergeRefs<T = any>(
-  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T> | undefined>
+  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T> | undefined | null>
 ): React.RefCallback<T> {
   return (value) => {
     refs.forEach((ref) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react";
 
 export function mergeRefs<T = any>(
-  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>
+  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T> | undefined>
 ): React.RefCallback<T> {
   return (value) => {
     refs.forEach((ref) => {


### PR DESCRIPTION
Thanks for the library!

## Summary

I use react-merge-refs for optional refs that may or may not be passed into a component:

```tsx
const mergedRef = mergeRefs([inputProps?.ref, localRef]);
```

This functionally works, but it shows a type error
> Type 'undefined' is not assignable to type 'LegacyRef<HTMLSpanElement> | MutableRefObject<HTMLSpanElement>'.

## Test plan

The included test checks the types are correct as well as the behavior when passing null or undefined to `mergeRefs`
